### PR TITLE
Add support for constants

### DIFF
--- a/sympytorch/sympy_module.py
+++ b/sympytorch/sympy_module.py
@@ -67,6 +67,13 @@ _global_func_lookup = {
 
 }
 
+number_symbols = [cls for cls in sympy.NumberSymbol.__subclasses__()]
+
+def number_symbol_to_torch(symbol, *args):
+    return torch.tensor(float(symbol))
+
+_global_func_lookup.update({s: ft.partial(number_symbol_to_torch, s()) for s in number_symbols})
+
 
 class _Node(torch.nn.Module):
     def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):
@@ -127,6 +134,8 @@ class _Node(torch.nn.Module):
             return self._sympy_func(self._name)
         elif issubclass(self._sympy_func, sympy.core.numbers.ImaginaryUnit):
             return sympy.I
+        elif issubclass(self._sympy_func, sympy.core.numbers.NumberSymbol):
+            return self._sympy_func()
         else:
             if issubclass(self._sympy_func, (sympy.Min, sympy.Max)):
                 evaluate = False

--- a/tests/test_sympymodule.py
+++ b/tests/test_sympymodule.py
@@ -111,6 +111,15 @@ def test_half2():
     assert (error**2).mean() < 1e-10, "error:{}".format((error**2).mean())
 
 
+def test_constants():
+    constants = [sympy.pi, sympy.E, sympy.GoldenRatio, sympy.TribonacciConstant, sympy.EulerGamma, sympy.Catalan]
+    mod = sympytorch.SymPyModule(expressions=constants)
+    mod.to(torch.float64)
+    assert mod.sympy() == constants, "mod: {}, y:{}".format(mod.sympy(), constants)
+    assert len([p.item() for p in mod.parameters()]) == 0
+    torch.testing.assert_allclose(mod(),torch.tensor([float(c) for c in constants]))
+
+
 def test_complex():
     # Simple complex number handing test
     x = sympy.symbols('x')


### PR DESCRIPTION
Enables support for all the subclasses of `NumberSymbol`, i.e. `sympy.pi, sympy.E, sympy.GoldenRatio, sympy.TribonacciConstant, sympy.EulerGamma, sympy.Catalan`