### PR TITLE
Add type annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,6 @@ setuptools.setup(name=name,
                  zip_safe=False,
                  python_requires=python_requires,
                  install_requires=install_requires,
-                 packages=[name])
+                 packages=[name],
+                 package_data={name: ['py.typed']}
+                 )

--- a/sympytorch/hide_floats_m.py
+++ b/sympytorch/hide_floats_m.py
@@ -1,12 +1,15 @@
+from typing import Dict, TypeVar
+
 import sympy
 
+ExprType = TypeVar("ExprType", bound=sympy.Expr)
 
-def hide_floats(expression):
-    _memodict = {}
+def hide_floats(expression:ExprType) -> ExprType:
+    _memodict:Dict[ExprType, ExprType] = {}
     return _hide_floats(expression, _memodict)
 
 
-def _hide_floats(expression, _memodict):
+def _hide_floats(expression:ExprType, _memodict:Dict[ExprType, ExprType]) -> ExprType:
     try:
         return _memodict[expression]
     except KeyError:
@@ -17,14 +20,15 @@ def _hide_floats(expression, _memodict):
     else:
         evaluate = True
 
+    new_expression:ExprType
     if issubclass(expression.func, sympy.Float):
-        new_expression = sympy.UnevaluatedExpr(expression)
+        new_expression = sympy.UnevaluatedExpr(expression)  # type: ignore
     elif issubclass(expression.func, sympy.Integer):
         new_expression = expression
     elif issubclass(expression.func, sympy.Symbol):
         new_expression = expression
     else:
         new_expression = expression.func(
-            *[_hide_floats(arg, _memodict) for arg in expression.args], evaluate=evaluate)
+            *[_hide_floats(arg, _memodict) for arg in expression.args], evaluate=evaluate)  # type: ignore
     _memodict[expression] = new_expression
     return new_expression

--- a/sympytorch/sympy_module.py
+++ b/sympytorch/sympy_module.py
@@ -6,6 +6,7 @@ import torch
 from typing import Any, Dict, Callable, Generic, Type, TypeVar, List, Union, Tuple, TYPE_CHECKING, Sequence
 
 ExprType = TypeVar("ExprType", bound=sympy.Expr)
+T = TypeVar('T')
 
 if TYPE_CHECKING:
     # Because there are methods of our class objects below called `sympy` that implicitly override
@@ -13,8 +14,8 @@ if TYPE_CHECKING:
     # needs to know that we're referring to the sympy module in our type annotations.
     import sympy as sympy_
 
-def _reduce(fn):
-    def fn_(*args):
+def _reduce(fn:Callable[..., T]) -> Callable[..., T]:
+    def fn_(*args:Any) -> T:
         return ft.reduce(fn, args)
     return fn_
 

--- a/sympytorch/sympy_module.py
+++ b/sympytorch/sympy_module.py
@@ -1,18 +1,27 @@
+from __future__ import annotations
 import collections as co
 import functools as ft
 import sympy
 import torch
+from typing import Any, Dict, Callable, Generic, Type, TypeVar, List, Union, Tuple, TYPE_CHECKING, Sequence
 
+ExprType = TypeVar("ExprType", bound=sympy.Expr)
+
+if TYPE_CHECKING:
+    # Because there are methods of our class objects below called `sympy` that implicitly override
+    # the `sympy` name in the global namespace while defining other methods, our type checker
+    # needs to know that we're referring to the sympy module in our type annotations.
+    import sympy as sympy_
 
 def _reduce(fn):
     def fn_(*args):
         return ft.reduce(fn, args)
     return fn_
 
-def _I(*args):
+def _I(*args: Any) -> torch.Tensor:
     return torch.tensor(1j)
 
-_global_func_lookup = {
+_global_func_lookup:Dict[Union[Type[sympy.Basic], Callable[..., Any]], Callable[..., torch.Tensor]] = {
     sympy.Mul: _reduce(torch.mul),
     sympy.Add: _reduce(torch.add),
     sympy.div: torch.div,
@@ -64,22 +73,25 @@ _global_func_lookup = {
     sympy.Determinant: torch.det,
     sympy.core.numbers.ImaginaryUnit: _I,
     sympy.conjugate: torch.conj,
-
 }
 
 number_symbols = [cls for cls in sympy.NumberSymbol.__subclasses__()]
 
-def number_symbol_to_torch(symbol, *args):
+def number_symbol_to_torch(symbol:sympy.NumberSymbol, *args: Any) -> torch.Tensor:
     return torch.tensor(float(symbol))
 
 _global_func_lookup.update({s: ft.partial(number_symbol_to_torch, s()) for s in number_symbols})
 
 
-class _Node(torch.nn.Module):
-    def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):
+class _Node(torch.nn.Module, Generic[ExprType]):
+    def __init__(self, *, expr: ExprType, _memodict:Dict[sympy.Basic, torch.nn.Module], _func_lookup, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._sympy_func = expr.func
+        self._sympy_func: Type[ExprType] = expr.func
+
+        self._torch_func: Callable[..., torch.Tensor]
+        self._args: Union[torch.nn.ModuleList, Tuple[Callable[[Dict[str, torch.Tensor]], torch.Tensor], ...]]
+        self._value: Any
 
         if issubclass(expr.func, sympy.Float):
             self._value = torch.nn.Parameter(torch.tensor(float(expr)))
@@ -90,6 +102,9 @@ class _Node(torch.nn.Module):
             self._torch_func = lambda: self._value
             self._args = ()
         elif issubclass(expr.func, sympy.Rational):
+            self._numerator: torch.Tensor
+            self._denominator: torch.Tensor
+            assert isinstance(expr, sympy.Rational)
             self.register_buffer('_numerator', torch.tensor(expr.p, dtype=torch.get_default_dtype()))
             self.register_buffer('_denominator', torch.tensor(expr.q, dtype=torch.get_default_dtype()))
             self._torch_func = lambda: self._numerator / self._denominator
@@ -97,29 +112,33 @@ class _Node(torch.nn.Module):
         elif issubclass(expr.func, sympy.UnevaluatedExpr):
             if len(expr.args) != 1 or not issubclass(expr.args[0].func, sympy.Float):
                 raise ValueError("UnevaluatedExpr should only be used to wrap floats.")
+            assert isinstance(expr.args[0], sympy.Float)
             self.register_buffer('_value', torch.tensor(float(expr.args[0])))
             self._torch_func = lambda: self._value
             self._args = ()
         elif issubclass(expr.func, sympy.Symbol):
+            assert isinstance(expr, sympy.Symbol)
             self._name = expr.name
             self._torch_func = lambda value: value
             self._args = ((lambda memodict: memodict[expr.name]),)
         else:
             self._torch_func = _func_lookup[expr.func]
-            args = []
+            args:List[torch.nn.Module] = []
             for arg in expr.args:
                 try:
                     arg_ = _memodict[arg]
                 except KeyError:
-                    arg_ = type(self)(expr=arg, _memodict=_memodict, _func_lookup=_func_lookup, **kwargs)
+                    arg_ = type(self)(expr=arg, _memodict=_memodict, _func_lookup=_func_lookup, **kwargs)  # type: ignore
                     _memodict[arg] = arg_
                 args.append(arg_)
             self._args = torch.nn.ModuleList(args)
 
-    def sympy(self, _memodict):
+    def sympy(self, _memodict: Dict[_Node, sympy_.Expr]) -> ExprType:
         if issubclass(self._sympy_func, sympy.Float):
+            assert isinstance(self._value, torch.nn.Parameter)
             return self._sympy_func(self._value.item())
         elif issubclass(self._sympy_func, sympy.UnevaluatedExpr):
+            assert isinstance(self._value, torch.Tensor)
             return self._sympy_func(self._value.item())
         elif issubclass(self._sympy_func, (type(sympy.S.NegativeOne), type(sympy.S.One), type(sympy.S.Zero))):
             return self._sympy_func()
@@ -143,15 +162,16 @@ class _Node(torch.nn.Module):
                 evaluate = True
             args = []
             for arg in self._args:
+                assert isinstance(arg, _Node)
                 try:
                     arg_ = _memodict[arg]
                 except KeyError:
                     arg_ = arg.sympy(_memodict)
                     _memodict[arg] = arg_
                 args.append(arg_)
-            return self._sympy_func(*args, evaluate=evaluate)
+            return self._sympy_func(*args, evaluate=evaluate)  # type: ignore
 
-    def forward(self, memodict):
+    def forward(self, memodict) -> torch.Tensor:
         args = []
         for arg in self._args:
             try:
@@ -174,7 +194,7 @@ class SymPyModule(torch.nn.Module):
         _func_lookup = co.ChainMap(_global_func_lookup, extra_funcs)
 
         _memodict = {}
-        self._nodes = torch.nn.ModuleList(
+        self._nodes: Sequence[_Node] = torch.nn.ModuleList(  # type: ignore
             [_Node(expr=expr, _memodict=_memodict, _func_lookup=_func_lookup) for expr in expressions]
         )
         self._expressions_string = str(expressions)
@@ -182,11 +202,11 @@ class SymPyModule(torch.nn.Module):
     def __repr__(self):
         return f"{type(self).__name__}(expressions={self._expressions_string})"
 
-    def sympy(self):
-        _memodict = {}
+    def sympy(self) -> List[sympy.Expr]:
+        _memodict:Dict[_Node, sympy.Expr] = {}
         return [node.sympy(_memodict) for node in self._nodes]
 
-    def forward(self, **symbols):
+    def forward(self, **symbols:Any) -> torch.Tensor:
         out = [node(symbols) for node in self._nodes]
         out = torch.broadcast_tensors(*out)
         return torch.stack(out, dim=-1)

--- a/tests/test_sympymodule.py
+++ b/tests/test_sympymodule.py
@@ -111,7 +111,7 @@ def test_half2():
     assert (error**2).mean() < 1e-10, "error:{}".format((error**2).mean())
 
 
-def test_constants():
+def test_constants2():
     constants = [sympy.pi, sympy.E, sympy.GoldenRatio, sympy.TribonacciConstant, sympy.EulerGamma, sympy.Catalan]
     mod = sympytorch.SymPyModule(expressions=constants)
     mod.to(torch.float64)


### PR DESCRIPTION
Fixes #1. 

With these added type hints, the package now passes pyright and only has false positives in mypy (where mypy is failing to bind Type[ExprType] properly). There are a few type ignores in places where duck typing is used (refactoring the code just for static typing in a few lines seemed like a waste), and there are a few internal `assert isinstance` checks to help the type checkers in a few tough-to-infer spots.

This PR also adds a `py.typed` file, so that external code can make use of the type hints.

Thank you for putting together such a wonderful tool.