### PR TITLE
fix: fix broken integer tensor implementation and include unit tests

### DIFF
--- a/sympytorch/sympy_module.py
+++ b/sympytorch/sympy_module.py
@@ -86,7 +86,7 @@ class _Node(torch.nn.Module):
             self._torch_func = lambda: self._value
             self._args = ()
         elif issubclass(expr.func, sympy.Integer):
-            self._value = int(expr)
+            self._value = torch.tensor(int(expr))
             self._torch_func = lambda: self._value
             self._args = ()
         elif issubclass(expr.func, sympy.Rational):

--- a/tests/test_sympymodule.py
+++ b/tests/test_sympymodule.py
@@ -159,3 +159,18 @@ def test_complex():
     # Correctness within single precision
     error = np.sum(np.abs(torch_eval.detach().numpy() - np_eval))
     assert error < 1e-7, "np v torch complex error:{}".format(error)
+
+def test_integers():
+    m = sympytorch.SymPyModule(expressions=[sympy.core.numbers.Zero()])
+    assert m() == torch.tensor([0.0])
+
+    m = sympytorch.SymPyModule(expressions=[sympy.core.numbers.One()])
+    assert m() == torch.tensor([1.0])
+
+    m = sympytorch.SymPyModule(expressions=[sympy.core.numbers.NegativeOne()])
+    assert m() == torch.tensor([-1.0])
+
+    for i in range(-10, 10):
+        m = sympytorch.SymPyModule(expressions=[sympy.core.numbers.Integer(i)])
+        assert m() == torch.tensor([float(i)])
+


### PR DESCRIPTION
Fixes #11.

Using integers as expressions would set the Node's `_value` attribute to an integer. When running forward on such a node, it would attempt to broadcast this integer, which is a TypeError. Wrapping this `_value` in a tensor first resolves this issue.

I also included unit tests for this functionality, including the minimal reproducible example provided in #11.